### PR TITLE
feat: add alias for kubectl

### DIFF
--- a/standalone-node/cluster_installers/sen-k3s-installer.sh
+++ b/standalone-node/cluster_installers/sen-k3s-installer.sh
@@ -101,6 +101,12 @@ sed 's|PATH="|PATH="'$K3S_BIN_PATH':|' /etc/environment > /tmp/environment.tmp &
 source /etc/environment
 export KUBECONFIG
 
+# Add alias for k to ~/.bashrc if not already present
+if ! grep -q "alias k=" ~/.bashrc; then
+  echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml $K3S_BIN_PATH/k3s kubectl'" >> ~/.bashrc
+  echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> ~/.bashrc
+fi
+
 # All pods deployed - write to log
 echo "$(date): The cluster installation is complete 12/12" | sudo tee -a /var/log/cluster-init.log | sudo tee /dev/tty0
 echo "$(date): The cluster installation is complete!"
@@ -139,9 +145,8 @@ IP address of the Node:
 	addresses 
 
 To access and view the cluster's pods run:
-	source /etc/environment
-	export KUBECONFIG
-	kubectl get pods -A
+  source ~/.bashrc
+  k get pods -A
 
 KUBECONFIG available at:
 	/etc/rancher/k3s/k3s.yaml

--- a/standalone-node/cluster_installers/sen-k3s-installer.sh
+++ b/standalone-node/cluster_installers/sen-k3s-installer.sh
@@ -102,9 +102,9 @@ source /etc/environment
 export KUBECONFIG
 
 # Add alias for k to ~/.bashrc if not already present
-if ! grep -q "alias k=" ~/.bashrc; then
-  echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml $K3S_BIN_PATH/k3s kubectl'" >> ~/.bashrc
-  echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> ~/.bashrc
+if ! grep -q "alias k=" /home/$user_name/.bashrc; then
+  echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml $K3S_BIN_PATH/k3s kubectl'" >> /home/$user_name/.bashrc
+  echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/$user_name/.bashrc
 fi
 
 # All pods deployed - write to log
@@ -145,7 +145,7 @@ IP address of the Node:
 	addresses 
 
 To access and view the cluster's pods run:
-  source ~/.bashrc
+  source /home/$user_name/.bashrc
   k get pods -A
 
 KUBECONFIG available at:

--- a/standalone-node/cluster_installers/sen-k3s-installer.sh
+++ b/standalone-node/cluster_installers/sen-k3s-installer.sh
@@ -101,11 +101,6 @@ sed 's|PATH="|PATH="'$K3S_BIN_PATH':|' /etc/environment > /tmp/environment.tmp &
 source /etc/environment
 export KUBECONFIG
 
-# Add alias for k to ~/.bashrc if not already present
-if ! grep -q "alias k=" /home/$user_name/.bashrc; then
-  echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml $K3S_BIN_PATH/k3s kubectl'" >> /home/$user_name/.bashrc
-  echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/$user_name/.bashrc
-fi
 
 # All pods deployed - write to log
 echo "$(date): The cluster installation is complete 12/12" | sudo tee -a /var/log/cluster-init.log | sudo tee /dev/tty0
@@ -145,7 +140,7 @@ IP address of the Node:
 	addresses 
 
 To access and view the cluster's pods run:
-  source /home/$user_name/.bashrc
+  source /home/<default-user>/.bashrc
   k get pods -A
 
 KUBECONFIG available at:

--- a/standalone-node/provisioning_scripts/cloud-init.yaml
+++ b/standalone-node/provisioning_scripts/cloud-init.yaml
@@ -17,7 +17,7 @@ runcmd:
     # Add user
     CONFIG_FILE="/etc/cloud/config-file"
     user_name=$(grep '^user_name=' "$CONFIG_FILE" | cut -d '=' -f2)
-    user_name=${user_name//\"/}
+    export user_name=${user_name//\"/}
     passwd=$(grep '^passwd=' "$CONFIG_FILE" | cut -d '=' -f2)
     passwd=${passwd//\"/}
     useradd -m -s /bin/bash $user_name && echo "$user_name:$passwd" | chpasswd && echo '$user_name ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/$user_name

--- a/standalone-node/provisioning_scripts/cloud-init.yaml
+++ b/standalone-node/provisioning_scripts/cloud-init.yaml
@@ -17,7 +17,7 @@ runcmd:
     # Add user
     CONFIG_FILE="/etc/cloud/config-file"
     user_name=$(grep '^user_name=' "$CONFIG_FILE" | cut -d '=' -f2)
-    export user_name=${user_name//\"/}
+    user_name=${user_name//\"/}
     passwd=$(grep '^passwd=' "$CONFIG_FILE" | cut -d '=' -f2)
     passwd=${passwd//\"/}
     useradd -m -s /bin/bash $user_name && echo "$user_name:$passwd" | chpasswd && echo '$user_name ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/$user_name

--- a/standalone-node/provisioning_scripts/install-os.sh
+++ b/standalone-node/provisioning_scripts/install-os.sh
@@ -396,7 +396,7 @@ EOF
         # export the /etc/enviroment values to .bashrc
 	echo "source /etc/environment" >> /home/$user_name/.bashrc
         echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/$user_name/.bashrc
-        echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml /user/bin/k3s kubectl'" >> /home/$user_name/.bashrc
+        echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml /usr/bin/k3s kubectl'" >> /home/$user_name/.bashrc
         #exit the su -$user_name
         exit
 EOT

--- a/standalone-node/provisioning_scripts/install-os.sh
+++ b/standalone-node/provisioning_scripts/install-os.sh
@@ -395,7 +395,8 @@ EOF
         chmod 600 ~/.ssh/authorized_keys
         # export the /etc/enviroment values to .bashrc
 	echo "source /etc/environment" >> /home/$user_name/.bashrc
-        echo "export KUBECONFIG" >> /home/$user_name/.bashrc
+        echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/$user_name/.bashrc
+        echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml /user/bin/k3s kubectl'" >> /home/$user_name/.bashrc
         #exit the su -$user_name
         exit
 EOT


### PR DESCRIPTION
# Pull Request Template

<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the
    checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable
    for the PR change.
-->

## Description

Adds an alias for the kubectl wrapper k3s provides. ``k`` is a common abbreviation used when aliasing kubectl.
Also exports the kubeconfig in case there are other tools installed that need access to it.

## Checklist

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
