### PR TITLE
fix: add helm specific env var

### DIFF
--- a/standalone-node/provisioning_scripts/install-os.sh
+++ b/standalone-node/provisioning_scripts/install-os.sh
@@ -415,6 +415,7 @@ EOF
         # export the /etc/enviroment values to .bashrc
 	echo "source /etc/environment" >> /home/$user_name/.bashrc
         echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> /home/$user_name/.bashrc
+        echo "export KUBE_CONFIG_PATH=/etc/rancher/k3s/k3s.yaml" >> /home/$user_name/.bashrc
         echo "alias k='KUBECONFIG=/etc/rancher/k3s/k3s.yaml /usr/bin/k3s kubectl'" >> /home/$user_name/.bashrc
         #exit the su -$user_name
         exit


### PR DESCRIPTION
# Pull Request Template

<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the
    checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable
    for the PR change.
-->

## Description
Adds an environment variable that points helm to the kubeconfig.

## How Has This Been Tested?

Tested on virtual setup. Wordpress deployed
![image](https://github.com/user-attachments/assets/0a321bf2-67d3-436a-be76-dea6b4e584a7)


## Checklist

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
