### PR TITLE
[cloud-init]: Creation of Openbox config file to launch xterm on alt+ctrl+t

### DIFF
--- a/standalone-node/docs/user-guide/desktop-virtualization-cloud-init.md
+++ b/standalone-node/docs/user-guide/desktop-virtualization-cloud-init.md
@@ -93,6 +93,7 @@ write_files:
     # Change `guest` to your intended username if not using 'guest' user.
   - path: /home/guest/.config/openbox/rc.xml
     permissions: '0644'
+    owner: 'guest:guest'
     content: |
       <openbox_config xmlns="http://openbox.org/3.6/rc">
         <keyboard>

--- a/standalone-node/docs/user-guide/desktop-virtualization-cloud-init.md
+++ b/standalone-node/docs/user-guide/desktop-virtualization-cloud-init.md
@@ -90,6 +90,20 @@ write_files:
     content: |
       SUBSYSTEM=="usb", MODE="0664", GROUP="qemu"
 
+    # Change `guest` to your intended username if not using 'guest' user.
+  - path: /home/guest/.config/openbox/rc.xml
+    permissions: '0644'
+    content: |
+      <openbox_config xmlns="http://openbox.org/3.6/rc">
+        <keyboard>
+          <keybind key="A-C-t">
+            <action name="Execute">
+              <command>xterm</command>
+            </action>
+          </keybind>
+        </keyboard>
+      </openbox_config>
+
   - path: /etc/cloud/custom_network.conf
     permissions: '0644'
     content: |

--- a/standalone-node/docs/user-guide/desktop-virtualization-cloud-init.md
+++ b/standalone-node/docs/user-guide/desktop-virtualization-cloud-init.md
@@ -94,6 +94,7 @@ write_files:
   - path: /home/guest/.config/openbox/rc.xml
     permissions: '0644'
     owner: 'guest:guest'
+    defer: true
     content: |
       <openbox_config xmlns="http://openbox.org/3.6/rc">
         <keyboard>


### PR DESCRIPTION
# Pull Request Template

<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the
    checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable
    for the PR change.
-->

## Description

- Adding openbox config file to keybind the launch of xterm

## Any Newly Introduced Dependencies

- xterm should be part of the package.

## How Has This Been Tested?

PR for include xterm in IDV images: https://github.com/open-edge-platform/edge-microvisor-toolkit/pull/274
 
Developer build: https://cje-ba-prod01.devtools.intel.com/ccg-ecg-tiberos/job/Image_Build/job/On-Demand_Developer_Build/541/
 
Packages included: libutempter xterm helm intel-idv-services intel-desktop-virtualization-k3s intel-gpu-device-plugin k3s
 
IDV image in above build: https://af01p-png.devtools.intel.com/artifactory/tiberos-png-local/developer-builds/emt-X11-ITEP-71391/20250703.1034/

## Checklist

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
