### PR TITLE
[DOCS] unifying CODEOWNERS for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 * @Ram-srini @abjyoti @shankarsrinivas1 @punam20 @ipsita-npg @krishnajs
+
+
+# documentation content
+/standalone-node/docs  @open-edge-platform/open-edge-platform-docs-write @Ram-srini @abjyoti @shankarsrinivas1 @punam20 @ipsita-npg @krishnajs
+README.md              @open-edge-platform/open-edge-platform-docs-write @Ram-srini @abjyoti @shankarsrinivas1 @punam20 @ipsita-npg @krishnajs

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 # Contributors
 
-## Special thanks for all the people who had helped this project so far
+## Special thanks to all the people who have helped this project so far
 
 - [abjyoti](https://github.com/abjyoti)
 - [adorney99](https://github.com/adorney99)


### PR DESCRIPTION
## Description

Adjusting CODEOWNERS for easier documentation adjustments and group management (one documentation group across the organization).

## Checklist

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
