### PR TITLE
Update Multus CNI to v4.2.1-thick in install script

### DIFF
--- a/standalone-node/installation_scripts/download_images.sh
+++ b/standalone-node/installation_scripts/download_images.sh
@@ -51,12 +51,12 @@ images=(
 	docker.io/calico/cni:v3.30.1
 	docker.io/calico/kube-controllers:v3.30.1
 	docker.io/calico/node:v3.30.1
-	ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1
+	ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick
 	docker.io/intel/intel-gpu-plugin:0.32.1
 )
 
 manifests=(
-	https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.2.1/deployments/multus-daemonset.yml
+	https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.2.1/deployments/multus-daemonset-thick.yml
 	https://raw.githubusercontent.com/intel/intel-device-plugins-for-kubernetes/v0.32.1/deployments/gpu_plugin/base/intel-gpu-plugin.yaml
 	https://raw.githubusercontent.com/projectcalico/calico/v3.30.1/manifests/calico.yaml
 )
@@ -94,7 +94,7 @@ download_extension_manifests () {
 		fi
 		if [[ "${name}" == "multus-daemonset.yml" ]]; then
 			# Replace the image tag in the multus manifest
-			sed -i 's|ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot|ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1|g' "${name}"		
+			sed -i 's|ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot|ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick |g' "${name}"		
 		fi
 	done
 	cd ../../


### PR DESCRIPTION
## Description

This pull request updates the Multus CNI image and manifest references in the `download_images.sh` script to use the "thick" variant. This ensures compatibility with the desired deployment configuration.

### Updates to Multus CNI references:

* Updated the Multus CNI image from `ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1` to `ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.1-thick` in the `images` array.
* Updated the Multus CNI manifest URL to point to the "thick" variant (`multus-daemonset-thick.yml`) in the `manifests` array.
* Modified the `download_extension_manifests` function to replace the Multus CNI image tag with the "thick" variant in the downloaded manifest.Switched Multus CNI image and manifest references from v4.2.1 to v4.2.1-thick in the download_images.sh script. Also updated the sed replacement to match the new image tag in the manifest.

## Any Newly Introduced Dependencies

multus-thick v4.2.1 

## How Has This Been Tested?

Edge node 

## Checklist

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
