### PR TITLE
Remove publishing installer binary to no-auth registry

### DIFF
--- a/standalone-node/Makefile
+++ b/standalone-node/Makefile
@@ -82,13 +82,5 @@ list:
 artifact-publish:
 	@# Help: Runs file upload stage
 	@echo "---Uploading all build tar files---"
-	dest_path="s3://ensp-prod-rs-files/files-edge-orch/repository/standalone-node/non-rt/base"; \
-	tar_file="installation_scripts/out/standalone-installation-files.tar.gz"; \
-	if [ -f "$$tar_file" ]; then \
-		echo "Uploading $$tar_file ..."; \
-		aws s3 cp "$$tar_file" "$$dest_path"/standalone-installation-files-$(VERSION).tar.gz || { echo "Upload failed for $$tar_file"; exit 1; }; \
-	else \
-		echo "Tar file $$tar_file not found!"; \
-		exit 1; \
-	fi
+	echo $@
 	@echo "---All uploads done---"


### PR DESCRIPTION
No binary release published for EMT-S due to Obligations,

# Pull Request Template

<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the
    checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable
    for the PR change.
-->

## Description

EMT-S is open source release. The USB installer binary image will not be distributed/released through no-auth RS fileserver.

Fixes # (issue)

## Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information, and how they are used in the project.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions
so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
