### PR TITLE
Allow Kubernetes cluster access from development system

### DIFF
--- a/standalone-node/installation_scripts/config-file
+++ b/standalone-node/installation_scripts/config-file
@@ -105,3 +105,5 @@ write_files: []
 #     - systemctl restart myservice
 #     - bash /etc/cloud/test.sh
 runcmd: 
+    # Allow helm/kubectl access from external development system
+    - iptables -A INPUT -p tcp --dport 6443 -j ACCEPT


### PR DESCRIPTION
port 6443 needs to open and accessible for the kubectl/hlem commands support from external development system.

# Pull Request Template

<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the
    checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable
    for the PR change.
-->

## Description

Allow Kubernetes cluster access from development system

Fixes # (issue)

## Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information, and how they are used in the project.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions
so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
