### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,19 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/standalone-node"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the Dependabot configuration to introduce a cooldown period for automated dependency updates. This helps reduce the frequency of pull requests, making it easier to manage and review them.

Dependabot configuration improvements:

* Added a `cooldown` setting with `default-days: 7` to each package ecosystem configuration in `.github/dependabot.yml`, ensuring that Dependabot waits at least 7 days before creating new pull requests for the same dependency.