### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-standalone-node.yaml
+++ b/.github/workflows/post-merge-standalone-node.yaml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "standalone-node/**"
+    tags:
+      - '*'
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request makes a small update to the workflow trigger configuration in `.github/workflows/post-merge-standalone-node.yaml`. The change ensures that the workflow will also run when any tag is pushed, in addition to the existing triggers.