### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge-standalone-node.yaml
+++ b/.github/workflows/post-merge-standalone-node.yaml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - "standalone-node/**"
-    tags:
-      - '*'
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request makes a small change to the workflow trigger configuration by removing the `tags` filter from the `.github/workflows/post-merge-standalone-node.yaml` file. This means the workflow will no longer be triggered by tag pushes.